### PR TITLE
레이어 별 레이어 추가 가능 여부를 판별하는 로직 추가

### DIFF
--- a/deepblock-ai/src/main/java/org/kok202/deepblock/ai/entity/enumerator/LayerType.java
+++ b/deepblock-ai/src/main/java/org/kok202/deepblock/ai/entity/enumerator/LayerType.java
@@ -21,6 +21,8 @@ public enum LayerType {
      * NOT REAL LAYER
      **********************************************************/
     INPUT_LAYER,
+    SPLIT_IN_LAYER,
+    SPLIT_OUT_LAYER,
 
     /**********************************************************
      * NOT SUPPORT

--- a/deepblock-gui/src/main/java/org/kok202/deepblock/canvas/block/layer/InputBlockNode.java
+++ b/deepblock-gui/src/main/java/org/kok202/deepblock/canvas/block/layer/InputBlockNode.java
@@ -13,16 +13,21 @@ public class InputBlockNode extends LayerBlockNode {
                         CanvasConstant.COLOR_GRAY,
                         CanvasConstant.COLOR_GRAY,
                         CanvasConstant.COLOR_GRAY,
-                        CanvasConstant.COLOR_DARK_GRAY,
-                        CanvasConstant.COLOR_GRAY
+                        CanvasConstant.CONTEXT_COLOR_IMPOSSIBLE_APPEND,
+                        CanvasConstant.CONTEXT_COLOR_POSSIBLE_APPEND
                 },
                 new Color[]{
                         CanvasConstant.COLOR_GRAY,
                         CanvasConstant.COLOR_GRAY,
                         CanvasConstant.COLOR_GRAY,
                         CanvasConstant.COLOR_GRAY,
-                        CanvasConstant.COLOR_DARK_GRAY,
-                        CanvasConstant.COLOR_YELLOW
+                        CanvasConstant.CONTEXT_COLOR_IMPOSSIBLE_APPEND,
+                        CanvasConstant.CONTEXT_COLOR_POSSIBLE_APPEND
                 });
+    }
+
+    @Override
+    public boolean isPossibleToAppendFront() {
+        return false;
     }
 }

--- a/deepblock-gui/src/main/java/org/kok202/deepblock/canvas/block/layer/LayerBlockNode.java
+++ b/deepblock-gui/src/main/java/org/kok202/deepblock/canvas/block/layer/LayerBlockNode.java
@@ -4,6 +4,8 @@ import javafx.geometry.Point2D;
 import org.kok202.deepblock.ai.entity.Layer;
 import org.kok202.deepblock.canvas.block.BlockNode;
 import org.kok202.deepblock.canvas.singleton.CanvasConstant;
+import org.kok202.deepblock.canvas.singleton.CanvasSingleton;
+import org.kok202.deepblock.domain.structure.TreeNode;
 
 public abstract class LayerBlockNode extends BlockNode {
     public LayerBlockNode(Layer layer) {
@@ -14,22 +16,21 @@ public abstract class LayerBlockNode extends BlockNode {
                 new Point2D(
                         layer.getProperties().getOutputSize()[0] * CanvasConstant.NODE_UNIT,
                         layer.getProperties().getOutputSize()[1] * CanvasConstant.NODE_UNIT));
-//        blockLayerModel.setColors(new Color[]{
-//                CanvasConstant.COLOR_BLUE,
-//                CanvasConstant.COLOR_BLUE,
-//                CanvasConstant.COLOR_BLUE,
-//                CanvasConstant.COLOR_BLUE,
-//                CanvasConstant.COLOR_YELLOW,
-//                CanvasConstant.COLOR_YELLOW});
-//        blockLayerModel.refreshBlockCover();
-//        or
-//        blockLayerModel.setTextures(new String[]{
-//                getClass().getClassLoader().getResource("images/sample_texture.png").toString(),
-//                getClass().getClassLoader().getResource("images/sample_texture.png").toString(),
-//                getClass().getClassLoader().getResource("images/sample_texture.png").toString(),
-//                getClass().getClassLoader().getResource("images/sample_texture.png").toString(),
-//                getClass().getClassLoader().getResource("images/sample_texture.png").toString(),
-//                getClass().getClassLoader().getResource("images/sample_texture.png").toString()});
-//        blockLayerModel.refreshBlockCover();
+    }
+
+    @Override
+    public boolean isPossibleToAppendFront() {
+        TreeNode<BlockNode> frontTreeNode = CanvasSingleton.getInstance()
+                .getBlockNodeManager()
+                .findTreeNodeByLayerId(this.getBlockInfo().getLayer().getId());
+        return frontTreeNode.getParent() == null;
+    }
+
+    @Override
+    public boolean isPossibleToAppendBack() {
+        TreeNode<BlockNode> frontTreeNode = CanvasSingleton.getInstance()
+                .getBlockNodeManager()
+                .findTreeNodeByLayerId(this.getBlockInfo().getLayer().getId());
+        return frontTreeNode.getChildren().isEmpty();
     }
 }

--- a/deepblock-gui/src/main/java/org/kok202/deepblock/canvas/block/layer/OutputBlockNode.java
+++ b/deepblock-gui/src/main/java/org/kok202/deepblock/canvas/block/layer/OutputBlockNode.java
@@ -13,16 +13,21 @@ public class OutputBlockNode extends LayerBlockNode {
                         CanvasConstant.COLOR_GRAY,
                         CanvasConstant.COLOR_GRAY,
                         CanvasConstant.COLOR_GRAY,
-                        CanvasConstant.COLOR_DARK_GRAY,
-                        CanvasConstant.COLOR_YELLOW
+                        CanvasConstant.CONTEXT_COLOR_POSSIBLE_APPEND,
+                        CanvasConstant.CONTEXT_COLOR_IMPOSSIBLE_APPEND
                 },
                 new Color[]{
-                        CanvasConstant.COLOR_GRAY,
-                        CanvasConstant.COLOR_GRAY,
-                        CanvasConstant.COLOR_GRAY,
-                        CanvasConstant.COLOR_GRAY,
-                        CanvasConstant.COLOR_DARK_GRAY,
-                        CanvasConstant.COLOR_YELLOW
+                        CanvasConstant.COLOR_RED,
+                        CanvasConstant.COLOR_RED,
+                        CanvasConstant.COLOR_RED,
+                        CanvasConstant.COLOR_RED,
+                        CanvasConstant.CONTEXT_COLOR_POSSIBLE_APPEND,
+                        CanvasConstant.CONTEXT_COLOR_IMPOSSIBLE_APPEND
                 });
+    }
+
+    @Override
+    public boolean isPossibleToAppendBack() {
+        return false;
     }
 }

--- a/deepblock-gui/src/main/java/org/kok202/deepblock/canvas/content/BlockInsertionHandler.java
+++ b/deepblock-gui/src/main/java/org/kok202/deepblock/canvas/content/BlockInsertionHandler.java
@@ -35,13 +35,20 @@ public class BlockInsertionHandler {
         Node pickResultNode = pickResult.getIntersectedNode();
         if(pastBlockHexahedronVerticalFace != pickResultNode){
             if(pastBlockHexahedronVerticalFace != null){
-                pastBlockHexahedronVerticalFace.setColor(CanvasConstant.COLOR_YELLOW);
+                pastBlockHexahedronVerticalFace.setColor(CanvasConstant.CONTEXT_COLOR_POSSIBLE_APPEND);
             }
         }
         if(pickResultNode instanceof HexahedronVerticalFace){
             HexahedronVerticalFace targetFace = (HexahedronVerticalFace) pickResultNode;
-            targetFace.setColor(CanvasConstant.COLOR_RED);
-            pastBlockHexahedronVerticalFace = targetFace;
+            BlockNode targetBlockNode = PickResultNodeUtil.convertToBlockNode(pickResult);
+            if(pickResultNode instanceof HexahedronTopFace && targetBlockNode.isPossibleToAppendFront()){
+                targetFace.setColor(CanvasConstant.CONTEXT_COLOR_TRY_TO_APPEND);
+                pastBlockHexahedronVerticalFace = targetFace;
+            }
+            else if(pickResultNode instanceof HexahedronBottomFace && targetBlockNode.isPossibleToAppendBack()){
+                targetFace.setColor(CanvasConstant.CONTEXT_COLOR_TRY_TO_APPEND);
+                pastBlockHexahedronVerticalFace = targetFace;
+            }
         }
     }
 
@@ -51,15 +58,15 @@ public class BlockInsertionHandler {
         if(pickResultNode instanceof HexahedronVerticalFace){
             BlockNode targetBlockNode = PickResultNodeUtil.convertToBlockNode(pickResult);
 
-            if(pickResultNode instanceof HexahedronTopFace){
+            if(pickResultNode instanceof HexahedronTopFace && targetBlockNode.isPossibleToAppendFront()){
                 appendFrontToSpecificBlock(materialInsertionInfoHolder.getLayerType(), targetBlockNode);
             }
-            else if(pickResultNode instanceof HexahedronBottomFace){
+            else if(pickResultNode instanceof HexahedronBottomFace && targetBlockNode.isPossibleToAppendBack()){
                 appendBackToSpecificBlock(materialInsertionInfoHolder.getLayerType(), targetBlockNode);
             }
 
             if(pastBlockHexahedronVerticalFace != null){
-                pastBlockHexahedronVerticalFace.setColor(CanvasConstant.COLOR_YELLOW);
+                pastBlockHexahedronVerticalFace.setColor(CanvasConstant.CONTEXT_COLOR_IMPOSSIBLE_APPEND);
             }
         }
         else if(pickResultNode instanceof CoordinateGiantMesh){

--- a/deepblock-gui/src/main/java/org/kok202/deepblock/canvas/content/Coordinate.java
+++ b/deepblock-gui/src/main/java/org/kok202/deepblock/canvas/content/Coordinate.java
@@ -24,12 +24,12 @@ public class Coordinate extends Group {
             getChildren().add(zAxis);
         }
 
-        getChildren().add(createGiantMesh(CanvasConstant.COORDINATE_SIZE, CanvasConstant.COORDINATE_DEPTH, CanvasConstant.COLOR_DARK_GRAY));
+        getChildren().add(createGiantMesh(CanvasConstant.COORDINATE_SIZE, CanvasConstant.COORDINATE_DEPTH, CanvasConstant.CONTEXT_COLOR_BACKGROUND));
     }
 
     private Box createAxis(double x, double y, double z){
         PhongMaterial material = new PhongMaterial();
-        material.setDiffuseColor(CanvasConstant.COLOR_GRAY);
+        material.setDiffuseColor(CanvasConstant.CONTEXT_COLOR_COORDINATE_AXIS);
         Box box = new Box(x,y,z);
         box.setMaterial(material);
         return box;

--- a/deepblock-gui/src/main/java/org/kok202/deepblock/canvas/polygon/block/Hexahedron.java
+++ b/deepblock-gui/src/main/java/org/kok202/deepblock/canvas/polygon/block/Hexahedron.java
@@ -104,4 +104,9 @@ public class Hexahedron {
     public void addedToScene(Group sceneGroup){
         sceneGroup.getChildren().addAll(faces);
     }
+
+    public void setVisible(boolean visible){
+        for(HexahedronFace face : faces)
+            face.setVisible(visible);
+    }
 }

--- a/deepblock-gui/src/main/java/org/kok202/deepblock/canvas/singleton/CanvasConstant.java
+++ b/deepblock-gui/src/main/java/org/kok202/deepblock/canvas/singleton/CanvasConstant.java
@@ -20,12 +20,19 @@ public class CanvasConstant {
     public static final double COORDINATE_MESH_BOLD_THICKNESS = 0.01;
     public static final double COORDINATE_MESH_NORM_THICKNESS = 0.003;
 
+    public static final Color COLOR_LIGHT_GRAY = Color.rgb(128, 128, 128);
     public static final Color COLOR_GRAY = Color.rgb(89, 91, 93);
     public static final Color COLOR_DARK_GRAY = Color.rgb(60, 63, 65);
     public static final Color COLOR_WHITE = Color.rgb(255, 255, 255);
     public static final Color COLOR_YELLOW = Color.rgb(255, 214, 146);
     public static final Color COLOR_RED = Color.rgb(255, 99, 99);
     public static final Color COLOR_BLUE = Color.rgb(77, 210, 255);
+
+    public static final Color CONTEXT_COLOR_POSSIBLE_APPEND = COLOR_YELLOW;
+    public static final Color CONTEXT_COLOR_TRY_TO_APPEND = COLOR_RED;
+    public static final Color CONTEXT_COLOR_IMPOSSIBLE_APPEND = COLOR_LIGHT_GRAY;
+    public static final Color CONTEXT_COLOR_BACKGROUND = COLOR_DARK_GRAY;
+    public static final Color CONTEXT_COLOR_COORDINATE_AXIS = COLOR_GRAY;
 
 //    public static final Font BOLD_FONT_IN_CANVAS = Font.font("NanumGothicCoding", FontWeight.BOLD, 64);
     public static final Font BOLD_FONT_IN_CANVAS = Font.font(null, FontWeight.BOLD, 64); // size is detail


### PR DESCRIPTION
- Block 에 activation layer 의 존재 여부에 따라 Block 의 면적이 겹쳐서 보이던 문제해결
- 레이어 별로 연결된 레이어의 존재여부를 판별하여 추가 가능 여부를 판별하도록 변경
- 의미를 가진 Color 는 따로 분류