### PR TITLE
Fix update nd4j dl4j

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ For someone who want to study deep learning. try this application with below rec
   
 ## Comment
 - Double click block : connection start.
+- If you want to change language, change setting and restart application.  
 
 ## TODO 
 - Check training RNN correctly. (bug(?)).

--- a/dluid-ai/pom.xml
+++ b/dluid-ai/pom.xml
@@ -11,8 +11,8 @@
     <artifactId>dluid-ai</artifactId>
 
     <properties>
-        <nd4j.version>1.0.0-beta4</nd4j.version>
-        <dl4j.version>1.0.0-beta4</dl4j.version>
+        <nd4j.version>1.0.0-beta6</nd4j.version>
+        <dl4j.version>1.0.0-beta6</dl4j.version>
         <junit.version>4.11</junit.version>
     </properties>
 

--- a/dluid-domain/pom.xml
+++ b/dluid-domain/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <lombok.version>1.18.6</lombok.version>
-        <jackson.version>2.10.2</jackson.version>
+        <jackson.version>2.10.0</jackson.version>
         <poi.version>4.1.0</poi.version>
         <poi-ooxml.version>4.1.0</poi-ooxml.version>
         <common-compress.version>1.19</common-compress.version>

--- a/dluid-domain/src/main/java/org/kok202/dluid/domain/util/Counter.java
+++ b/dluid-domain/src/main/java/org/kok202/dluid/domain/util/Counter.java
@@ -35,8 +35,8 @@ public class Counter {
 
     public double calcPercent(){
         if(count == max)
-            return 100;
-        double result = count / (double)(max) * 100;
+            return 1;
+        double result = count / (double)(max);
         return Math.round(result * ROUNDED_UNIT) / ROUNDED_UNIT;
     }
 


### PR DESCRIPTION
+ Bug on mac OS Catalina, can not run jar.
   - bug report : [libc++abi.dylib+0x30b4]
   - https://github.com/eclipse/deeplearning4j/issues/8156

+ Bug on training and test progress bar

+ Jackson library downgrade